### PR TITLE
Swap in retail content

### DIFF
--- a/RobotInterrogation/ClientApp/src/components/Interview.tsx
+++ b/RobotInterrogation/ClientApp/src/components/Interview.tsx
@@ -62,6 +62,7 @@ interface IState {
     outcome?: InterviewOutcome;
     choice: string[];
     packet: string;
+    prompt: string;
     penalty: string;
     primaryQuestions: IInterviewQuestion[];
     secondaryQuestions: IInterviewQuestion[];
@@ -84,6 +85,7 @@ export class Interview extends React.PureComponent<RouteComponentProps<{ id: str
             packet: '',
             penalty: '',
             primaryQuestions: [],
+            prompt: '',
             roles: [],
             secondaryQuestions: [],
             status: InterviewStatus.NotConnected,
@@ -181,6 +183,7 @@ export class Interview extends React.PureComponent<RouteComponentProps<{ id: str
 
                     return <InterviewerReadyToStart
                         primary={this.state.primaryQuestions}
+                        prompt={this.state.prompt}
                         secondary={this.state.secondaryQuestions}
                         suspectNote={this.state.suspectNote}
                         penalty={this.state.penalty}
@@ -203,6 +206,7 @@ export class Interview extends React.PureComponent<RouteComponentProps<{ id: str
                         conclude={conclude}
                         duration={this.state.duration}
                         penalty={this.state.penalty}
+                        prompt={this.state.prompt}
                         primary={this.state.primaryQuestions}
                         secondary={this.state.secondaryQuestions}
                         suspectNote={this.state.suspectNote}
@@ -267,6 +271,7 @@ export class Interview extends React.PureComponent<RouteComponentProps<{ id: str
                 packet: '',
                 penalty: '',
                 primaryQuestions: [],
+                prompt: '',
                 role: undefined,
                 roles: [],
                 secondaryQuestions: [],
@@ -319,9 +324,10 @@ export class Interview extends React.PureComponent<RouteComponentProps<{ id: str
             });
         });
 
-        this.connection.on('SetPacket', (packet: string) => {
+        this.connection.on('SetPacket', (packet: string, prompt: string) => {
             this.setState({
                 packet,
+                prompt,
                 status: InterviewStatus.ShowingPacket,
             });
         });

--- a/RobotInterrogation/ClientApp/src/components/interviewParts/InterviewerInProgress.tsx
+++ b/RobotInterrogation/ClientApp/src/components/interviewParts/InterviewerInProgress.tsx
@@ -4,6 +4,7 @@ import { Countdown } from './elements/Countdown';
 import { IInterviewQuestion, InterviewQuestion } from './elements/InterviewQuestion';
 
 interface IProps {
+    prompt: string,
     primary: IInterviewQuestion[],
     secondary: IInterviewQuestion[],
     suspectNote: string,
@@ -23,12 +24,13 @@ export class InterviewerInProgress extends React.PureComponent<IProps> {
         return <div>
             <h2>You are the interviewer.</h2>
             <p>Ask the suspect questions and decide whether they are human or a robot.</p>
+            <p>Prompt: {this.props.prompt}</p>
             <div>
                 {primary}
                 {secondary}
             </div>
             <p>Penalty: {this.props.penalty}</p>
-            <p>Suspect Note: {this.props.suspectNote}</p>
+            <p>Suspect Identity: {this.props.suspectNote}</p>
 
             <Countdown duration={this.props.duration} />
 

--- a/RobotInterrogation/ClientApp/src/components/interviewParts/InterviewerReadyToStart.tsx
+++ b/RobotInterrogation/ClientApp/src/components/interviewParts/InterviewerReadyToStart.tsx
@@ -3,6 +3,7 @@ import './ActionSet.css';
 import { IInterviewQuestion, InterviewQuestion } from './elements/InterviewQuestion';
 
 interface IProps {
+    prompt: string,
     primary: IInterviewQuestion[],
     secondary: IInterviewQuestion[],
     suspectNote: string,
@@ -17,13 +18,14 @@ export class InterviewerReadyToStart extends React.PureComponent<IProps> {
 
         return <div>
             <h2>You are the interviewer.</h2>
-            <p>When you are ready, ask the suspect to perform the penalty 3 times. When they have done so, confirm their suspect note, and start the timer.</p>
+            <p>When you are ready, ask the suspect to perform the penalty 3 times. When they have done so, confirm their identity, read them the prompt, and start the timer at the bottom of the page.</p>
+            <p>Prompt: {this.props.prompt}</p>
             <div>
                 {primary}
                 {secondary}
             </div>
             <p>Penalty: {this.props.penalty}</p>
-            <p>Suspect Note: {this.props.suspectNote}</p>
+            <p>Suspect Identity: {this.props.suspectNote}</p>
 
             <div className="actionSet">
                 <button onClick={this.props.ready} className="btn btn-primary">Start the Timer</button>

--- a/RobotInterrogation/ClientApp/src/components/interviewParts/elements/SuspectRole.tsx
+++ b/RobotInterrogation/ClientApp/src/components/interviewParts/elements/SuspectRole.tsx
@@ -26,7 +26,7 @@ export class SuspectRole extends React.PureComponent<IProps, {}> {
         const traits = this.props.role.traits.map((t, i) => <li className="suspectRole__trait" key={i}>{t}</li>);
         let displayName = this.props.role.type.replace('Robot', ' Robot');
         if (this.props.role.type !== "Human") {
-          displayName += `(${this.props.role.fault})`;
+          displayName += ` (${this.props.role.fault})`;
 		}
 
         return <div className={classes} onClick={onClick}>

--- a/RobotInterrogation/ClientApp/src/components/interviewParts/elements/SuspectRole.tsx
+++ b/RobotInterrogation/ClientApp/src/components/interviewParts/elements/SuspectRole.tsx
@@ -3,6 +3,7 @@ import './SuspectRole.css';
 
 export interface ISuspectRole {
     type: string;
+    fault: string;
     traits: string[],
 }
 
@@ -23,7 +24,10 @@ export class SuspectRole extends React.PureComponent<IProps, {}> {
         }
 
         const traits = this.props.role.traits.map((t, i) => <li className="suspectRole__trait" key={i}>{t}</li>);
-        const displayName = this.props.role.type.replace('Robot', ' Robot');
+        let displayName = this.props.role.type.replace('Robot', ' Robot');
+        if (this.props.role.type !== "Human") {
+          displayName += `(${this.props.role.fault})`;
+		}
 
         return <div className={classes} onClick={onClick}>
             <div className="suspectRole__name">{displayName}</div>

--- a/RobotInterrogation/Hubs/InterviewHub.cs
+++ b/RobotInterrogation/Hubs/InterviewHub.cs
@@ -24,7 +24,7 @@ namespace RobotInterrogation.Hubs
 
         Task ShowPacketChoice(string[] options);
         Task WaitForPacketChoice();
-        Task SetPacket(string packetName);
+        Task SetPacket(string packetName, string packetPrompt);
 
         Task ShowRoleSelection(List<SuspectRole> roles);
 
@@ -194,7 +194,7 @@ namespace RobotInterrogation.Hubs
             interview.Packet = Service.GetPacket(index);
 
             await Clients.Group(SessionID)
-                .SetPacket(interview.Packet.Description);
+                .SetPacket(interview.Packet.Description, interview.Packet.Prompt);
 
             interview.Status = InterviewStatus.SelectingRole;
         }

--- a/RobotInterrogation/Models/Interview.cs
+++ b/RobotInterrogation/Models/Interview.cs
@@ -22,6 +22,7 @@ namespace RobotInterrogation.Models
 
         public List<SuspectRole> Roles { get; } = new List<SuspectRole>();
 
+        public string Prompt { get; set;  }
         public List<Question> PrimaryQuestions { get; } = new List<Question>();
         public List<Question> SecondaryQuestions { get; } = new List<Question>();
     }

--- a/RobotInterrogation/Models/Packet.cs
+++ b/RobotInterrogation/Models/Packet.cs
@@ -4,7 +4,7 @@
     {
         public string Name { get; set; }
         public string Description { get; set; }
-
+        public string Prompt { get; set; }
         public Question[] PrimaryQuestions { get; set; }
         public Question[] SecondaryQuestions { get; set; }
 

--- a/RobotInterrogation/Models/SuspectRole.cs
+++ b/RobotInterrogation/Models/SuspectRole.cs
@@ -3,6 +3,7 @@
     public class SuspectRole
     {
         public SuspectRoleType Type { get; set; }
+        public string Fault { get; set; }
         public string[] Traits { get; set; }
     }
 }

--- a/RobotInterrogation/Services/InterviewService.cs
+++ b/RobotInterrogation/Services/InterviewService.cs
@@ -168,8 +168,8 @@ namespace RobotInterrogation.Services
 
         public void AllocateQuestions(Interview interview)
         {
-            AllocateRandomValues(interview.Packet.PrimaryQuestions, interview.PrimaryQuestions, 2);
-            AllocateRandomValues(interview.Packet.SecondaryQuestions, interview.SecondaryQuestions, 2);
+            AllocateRandomValues(interview.Packet.PrimaryQuestions, interview.PrimaryQuestions, 3);
+            AllocateRandomValues(interview.Packet.SecondaryQuestions, interview.SecondaryQuestions, 3);
         }
 
         public void AllocateSuspectNotes(Interview interview)
@@ -242,6 +242,7 @@ namespace RobotInterrogation.Services
                 interview.Outcome,
                 Duration = duration,
                 Packet = interview.Packet.Name,
+                Prompt = interview.Packet.Prompt,
                 PrimaryQuestions = interview.PrimaryQuestions.Select(q => q.Challenge).ToArray(),
                 SecondaryQuestions = interview.SecondaryQuestions.Select(q => q.Challenge).ToArray(),
                 SuspectNote = interview.SuspectNotes.First(),

--- a/RobotInterrogation/Services/InterviewService.cs
+++ b/RobotInterrogation/Services/InterviewService.cs
@@ -163,7 +163,7 @@ namespace RobotInterrogation.Services
 
         public void AllocateRoles(Interview interview)
         {
-            AllocateRandomValues(interview.Packet.Roles, interview.Roles, 3);
+            AllocateRandomValues(interview.Packet.Roles, interview.Roles, 1);
         }
 
         public void AllocateQuestions(Interview interview)
@@ -174,7 +174,7 @@ namespace RobotInterrogation.Services
 
         public void AllocateSuspectNotes(Interview interview)
         {
-            AllocateRandomValues(Configuration.SuspectNotes, interview.SuspectNotes, 2);
+            AllocateRandomValues(Configuration.SuspectNotes, interview.SuspectNotes, 3);
         }
 
         public InterviewOutcome GuessSuspectRole(Interview interview, bool guessIsRobot)

--- a/RobotInterrogation/Services/InterviewService.cs
+++ b/RobotInterrogation/Services/InterviewService.cs
@@ -246,6 +246,7 @@ namespace RobotInterrogation.Services
                 SecondaryQuestions = interview.SecondaryQuestions.Select(q => q.Challenge).ToArray(),
                 SuspectNote = interview.SuspectNotes.First(),
                 SuspectType = interview.Roles.First().Type,
+                SuspectFault = interview.Roles.First().Fault,
                 SuspectTraits = interview.Roles.First().Traits,
             };
 

--- a/RobotInterrogation/appsettings.json
+++ b/RobotInterrogation/appsettings.json
@@ -41,123 +41,115 @@
     "Duration": 300,
 
     "Penalties": [
-      "Apologize",
-      "Swear",
-      "Mispronounce a word",
-      "Say two consecutive rhyming words",
-      "Say the number of fingers held up on your left hand",
-      "Remain silent for ten seconds",
-      "Interrupt the investigator",
-      "Say your last name",
-      "Fail to complete a sentence",
-      "Say \"What\"",
-      "Say at least three consecutive letters",
-      "Begin a new sentence with the last word spoken",
-      "Take your hands off the table",
+      "Answer 3 questions w/o referencing your background",
+      "Say a word with at least five syllables",
       "Ask for clarification",
       "Restate a question in your own words",
-      "Say at least three letters in a row",
-      "Don't respond to a question",
-      "Say a word with at least five syllables",
-      "Say two conjugations in a row",
-      "Compliment the investigator",
-      "Say three consecutive words ending in the same letter",
-      "Say four consecutive words beginning with the same letter",
-      "Say the name of a punctuation mark",
-      "Refer to yourself in the third person"
+      "Remain silent for ten seconds",
+      "Interrupt the Investigator",
+      "Apologize",
+      "Say two consecutive rhyming words",
+      "Say the number of fingers held up on your left hand",
+      "Swear",
+      "Take your hands off the table",
+      "Say three consecutive words beginning with the same letter",
+      "Point at something",
+      "Say any three letters in a row",
+      "Begin and end a sentence with the same word",
+      "Say three words beginning with consecutive letters of the alphabet",
+      "Don't not use a double negative",
+      "Use an ordinal number other than \"first\"",
+      "Compliment the Investigator",
+      "Answer a question in exactly five words",
+      "Say the name of a punctuation mark"
     ],
 
     "SuspectNotes": [
-      "Disgraced scientist",
-      "Maker of false animals",
-      "Friends with the commissioner",
-      "Renowned professor",
-      "Reality TV contestant",
-      "Cult leader",
-      "Foreign ambassador",
-      "Motivational speaker",
-      "Professional criminal",
-      "Used van salesman",
-      "Popstar",
-      "Retired sports champion",
-      "Very old",
-      "Ran for mayor last year",
-      "Decorated robot war veteran",
-      "Former investigator",
-      "Dishonorably discharged from the military",
-      "World's second richest person",
-      "Conspiracy theorist",
-      "Mentalist",
+      "Reality TV Contestant",
+      "Disgraced Scientist",
+      "Renowned Professor",
+      "Very Old",
+      "Mayoral Candidate",
+      "Conspiracy Theorist",
+      "Former Investigator",
+      "Decorated Robot War Veteran",
+      "Professional Criminal",
+      "Sponsored by an Energy Drink Brand",
+      "Maker of False Animals",
+      "Retired Sports Champion",
+      "Used Van Dealer",
+      "Body Builder",
+      "Freelance Robot Hunter",
+      "Former Child Star",
       "Cannibal",
-      "Presidential impersonator",
-      "Amateur wrestler",
-      "Small child",
-      "Lifestyle designer",
-      "Clergy member",
+      "Robots' Rights Activist",
+      "World's Second Richest Person",
+      "Royalty",
+      "Butler to the Stars",
+      "Internal Affairs Agent",
+      "Dean of a Clown College",
+      "Amateur Wrestler",
       "\"The Butcher\"",
-      "Addict",
-      "Body builder",
-      "Taken a vow of service",
-      "President in-exile",
-      "Freelance robot hunter",
-      "Last of their name",
-      "Heir to a vast fortune",
-      "Blackmail victim",
-      "Royalty"
-    ],
+      "Dishonorably Discharged from the Military",
+      "Foreign Ambassador",
+      "Motivational Speaker",
+      "Popstar",
+      "Cult Leader"
+  ],
 
     "Packets": [
       {
-        "name": "Chair",
-        "description": "Process your Day",
+        "name": "Telephone",
+        "description": "Small Talk",
+        "prompt": "In a moment I'm going to ask you some questions about NORMAL, EVERYDAY THINGS. These will require you to share superficial details about your life, and make small talk about them. Answer honestly. If you are a human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "Share a plan for some time in the next seven days",
+            "challenge": "Share a short-term plan or goal",
             "examples": [
               "What are you doing this weekend?",
               "How will tomorrow be different from today?"
             ]
           },
           {
-            "challenge": "Describe a project or task they worked on recently",
+            "challenge": "Talk about something they do regularly",
             "examples": [
-              "What did you do today?",
-              "What have you read or played recently that you would recommend?"
+              "What do you do for a living?",
+              "What's your favorite hobby?"
             ]
           },
           {
-            "challenge": "Share a conversation they had recently or expect to have",
+            "challenge": "Share some information about their personal background",
             "examples": [
-              "Who did you talk to first today?",
-              "Tell me about someone you work with."
+              "Where did you grow up?",
+              "How many siblings do you have?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Guess what another person might have thought",
+            "challenge": "Share their feelings about something they already mentioned",
             "examples": [
-              "Tell me if the other person thought the conversation went badly or well.",
-              "How did the people you were with see it?"
+              "How does that make you feel?",
+              "What's your favorite thing about that?"
             ]
           },
           {
-            "challenge": "Describe something they enjoyed or expect to enjoy",
+            "challenge": "Explain how something they mentioned affects other people in their life",
             "examples": [
-              "What was a fun thing you did while you were there?",
-              "What hobbies or leisure activities do you plan to engage in this weekend?"
+              "How does your mother feel about that?",
+              "How does your boss feel about that?"
             ]
           },
           {
-            "challenge": "Describe a challenge they recently faced",
+            "challenge": "Share a complaint about something they already mentioned",
             "examples": [
-              "What was the hardest part of that conversation?",
-              "What did you struggle with today?"
+              "What makes that difficult?",
+              "If you could change anything about what happened what would you change?"
             ]
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -195,350 +187,94 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "Animals",
             "traits": [
-              "Mention an animal in response to 3 different questions.",
-              "Make an animal noise. (If this completes your obsession, wait 30 seconds before killing the investigator.)",
+              "Mention an animal in response to 3 different questions",
+              "Make an animal noise",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Thoroughness",
             "traits": [
-              "3 times, interrupt the investigator to add detail to a description.",
-              "Continue to describe something until interrupted.",
+              "3 times, interrupt the Investigator to add detail to a description",
+              "Continue to describe something until interrupted",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Conflict",
             "traits": [
-              "Describe 3 verbal disagreements you've had.",
-              "Insult the investigator 2 times.",
+              "Describe 3 verbal disagreements you've had",
+              "Insult the Investigator, 2 times",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Long Term Memory",
             "traits": [
-              "You may not mention any people other than strangers or enemies."
+              "You may not discuss anything that happened before you woke up this morning. (You may discuss habits and routines, if they are in the present tense.)"
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Friendship",
             "traits": [
-              "You may not discuss anthing that happened before you woke up this morning."
+              "You may not mention any people besides strangers or enemies."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Evaluation",
             "traits": [
-              "You may not express opinions.",
-              "You may only state observable facts."
+              "You may not express opinions. You may only state observable facts."
             ]
           }
-        ]
+       ]
       },
 
       {
-        "name": "Dragon",
-        "description": "Demonstrate Imagination",
+        "name": "Scissors",
+        "description": "Creative Problem Solving",
+        "prompt": "In a moment, I'm going to ask you some questions about CREATIVE PROBLEM-SOLVING. These will require you to solve various hypothetical problems, then modify your solutions based on certain constraints. Answer honestly. If you are a human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "Describe a new thing of a given type",
+            "challenge": "Describe how they would overcome an unusual obstacle",
             "examples": [
-              "If you could have any magical power, what would it be?",
-              "What's a question I should have asked you, but haven't?"
-            ]
-          },
-          {
-            "challenge": "Describe something the suspect has never seen",
-            "examples": [
-              "What would it be like to walk on a distant planet?",
-              "Describe an impossible shape for me."
-            ]
-          },
-          {
-            "challenge": "Continue a story you start",
-            "examples": [
-              "Once upon a time, a mouse, a bird and a sausage joined forces...",
-              "I didn't want to kill him, but..."
-            ]
-          }
-        ],
-        "secondaryQuestions": [
-          {
-            "challenge": "Explain the implications of something the suspect came up with",
-            "examples": [
-              "If the thing you described existed, what else would exist?",
-              "What would it be like to interact with the thing you've invented?"
-            ]
-          },
-          {
-            "challenge": "Imagine something again with an extra constraint",
-            "examples": [
-              "Now tell the story from the perspective of the horse...",
-              "Now describe the place again, in only six words."
-            ]
-          },
-          {
-            "challenge": "Describe the opposite of something the suspect has already described",
-            "examples": [
-              "Now tell the same story, but with a tragic ending.",
-              "And what magical power does your arch nemesis have?"
-            ]
-          }
-        ],
-        "roles": [
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "Explain where you got the idea for 3 things you've made up.",
-              "Guess the inspiration for 2 of the investigator's questions.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "Mention the same imagined thing in response to 4 questions.",
-              "Mention 3 imaginary locations.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "Give 1-word answers to 3 questions. Don't elaborate unless asked.",
-              "Answer 2 questions nonverbally. Stay silent until prompted.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "You many only mention objects that you can see from where you are sitting."
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "Once the investigator has mentioned a specific person, place or thing (other than you), you may no longer mention that thing."
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "Once you have mentioned an animal, vegetable, or mineral, you may not mention examples of the other two types of things for the rest of the round."
-            ]
-          }
-        ]
-      },
-
-      {
-        "name": "Rose",
-        "description": "Experience and Process Grief",
-        "primaryQuestions": [
-          {
-            "challenge": "Describe a time someone the suspect cared about was sad",
-            "examples": [
-              "What was the last thing that made your father cry?",
-              "What was the most difficult decision your parents ever had to make?"
-            ]
-          },
-          {
-            "challenge": "Explain how the suspect felt when they gained something they didn't want",
-            "examples": [
-              "How did you react when your parents explained death to you?",
-              "Tell me about a time you found out you were sick, and how you reacted."
-            ]
-          },
-          {
-            "challenge": "Explain how it felt to lose something/someone precious to the suspect",
-            "examples": [
-              "What was the hardest goodbye you've ever had to say? How did you cope?",
-              "Tell me about a goal that you had to abandon?"
-            ]
-          }
-        ],
-        "secondaryQuestions": [
-          {
-            "challenge": "Explain the implications of something the suspect came up with",
-            "examples": [
-              "If the thing you described existed, what else would exist?",
-              "What would it be like to interact with the thing you've invented?"
-            ]
-          },
-          {
-            "challenge": "Imagine something again with an extra constraint",
-            "examples": [
-              "Now tell the story from the perspective of the horse...",
-              "Now describe the place again, in only six words."
-            ]
-          },
-          {
-            "challenge": "Describe the opposite of something the suspect has already described",
-            "examples": [
-              "Now tell the same story, but with a tragic ending.",
-              "And what magical power does your arch nemesis have?"
-            ]
-          }
-        ],
-        "roles": [
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "Human",
-            "traits": [
-              "You have nothing to hide."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "Describe how 3 things seem unfair to you.",
-              "2 times, say what you think should have happened instead.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "3 times, blame someone else for something.",
-              "3 times, blame yourself for something.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "ViolentRobot",
-            "traits": [
-              "Describe dealing with 3 different tragedies the same way.",
-              "Refer to the same friend or family member 4 times.",
-              "Perform the penalty twice."
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "You may not say the words \"think,\" \"thought\", \"feel\" or \"felt.\""
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "You must describe emotions only using physical descriptions rather than names, e.g. \"crying\" instead of \"sad\" or \"sweaty palms\" instead of \"nervous.\""
-            ]
-          },
-          {
-            "type": "PatientRobot",
-            "traits": [
-              "You may only describe good consequences, and you must take credit for them."
-            ]
-          }
-        ]
-      },
-
-      {
-        "name": "Coffee",
-        "description": "Apply Creative Problem Solving",
-        "primaryQuestions": [
-          {
-            "challenge": "Describe at least five different uses for an ordinary object",
-            "examples": [
-              "How many uses for a paperclip can you come up with?",
-              "What do you think is the most versatile household object, and why?"
-            ]
-          },
-          {
-            "challenge": "Overcome an unusual obstacle",
-            "examples": [
-              "You are in a kitchen holding a small child. A dish towel catches fire. How do you put it out?",
+              "You are in a kitchen, holding a small child. A dish towel catches fire. How do you put it out?",
               "You are in a landslide. How do you survive?"
             ]
           },
           {
-            "challenge": "Solve an apparently unsolveable problem",
+            "challenge": "Attempt to solve an apparently unsolvable problem",
             "examples": [
-              "You wake up in a room with four seamless walls, an infinitely thick ceiling and floor. How do you escape?",
+              "You wake up in a featureless room with no exits. How do you escape?",
               "I'm going to tell the department you're a robot, and there's nothing you can do about it. What now?"
+            ]
+          },
+          {
+            "challenge": "Come up with a problem that would be solved by a given solution",
+            "examples": [
+              "What sort of problem might be solved by building a bomb?",
+              "What sort of problem might be solved by hiding under a table?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Describe a second, different solution to a problem",
+            "challenge": "Explain how they would prepare for or prevent a given problem",
             "examples": [
-              "How else would you solve it?",
-              "What if you couldn't get the resources that solution would require?"
+              "If you were designing this scenario, what could you add to make it easier?",
+              "How would you prepare for this if it were a real possibility?"
             ]
           },
           {
             "challenge": "Solve a problem again with an additional obstacle",
             "examples": [
-              "Could you improvise a solution again using only a screwdriver?",
+              "Could you improvise a solution using only a screwdriver?",
               "What if you had to do it without hands?"
             ]
           },
@@ -551,7 +287,7 @@
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -589,100 +325,386 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "Persistence",
             "traits": [
-              "Tell an anecdote about someone else in response to 3 questions.",
-              "Mention how you solved 2 problems the last time they arose.",
+              "2 times, describe a solution that would require extended monotonous labor",
+              "Describe using the same tool to solve 3 different problems",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Delegation",
             "traits": [
-              "Describe attempting the same solution in 3 scenarios.",
-              "Attempt 3 very similar solutions to the same problem.",
+              "In 3 scenarios, explain how someone else could help you solve a problem",
+              "In 3 scenarios, explain why you don't need to solve a problem",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Precedent",
             "traits": [
-              "Establish how you got into 3 hypothetical situations.",
-              "Reveal 2 things that qualify you to solve a given problem.",
+              "In 3 scenarios, mention a source of information about how to solve a problem",
+              "2 times, refer back to a solution you mentioned earlier",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "traits": [
-              "Any problem you solve, you must solve in two steps or less."
-            ]
-          },
-          {
-            "type": "PatientRobot",
+            "description": "Directness",
             "traits": [
               "You may not describe yourself accomplishing a goal with fewer than three steps."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Complexity",
             "traits": [
-              "You may not describe yourself taking any physical action. You may use the hypothetical \"you.\""
+              "Any problem you solve, you must solve in two steps or less."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Activity",
+            "traits": [
+              "You may not describe yourself taking any physical action. You must use the hypothetical \"you.\""
             ]
           }
-        ]
+       ]
       },
 
       {
-        "name": "Hourglass",
+        "name": "Unicorn",
+        "description": "Imagination",
+        "prompt": "In a moment, I'm going to ask you some questions about IMAGINATION. These will require you to invent original characters, stories, and ideas, and discuss the implications of those Inventions. Answer honestly. If you are a human, you have nothing to fear.",
+        "primaryQuestions": [
+          {
+            "challenge": "Invent a new thing of a given type",
+            "examples": [
+              "If you could have any magical power, what would it be?",
+              "What's a question I should have asked you, but didn't?"
+            ]
+          },
+          {
+            "challenge": "Describe something the suspect has never seen",
+            "examples": [
+              "What would it be like to walk on a distant planet?",
+              "Describe an impossible shape for me."
+            ]
+          },
+          {
+            "challenge": "Continue a story you start",
+            "examples": [
+              "Once upon a time, a mouse, a bird, and a sausage joined forces ...",
+              "I didn't want to kill him, but ..."
+            ]
+          }
+        ],
+        "secondaryQuestions": [
+          {
+            "challenge": "Describe the implication of something the suspect came up with",
+            "examples": [
+              "If the thing you described existed, what else would exist?",
+              "What would it be like to eat the thing you described?"
+            ]
+          },
+          {
+            "challenge": "Imagine something again with an extra constraint",
+            "examples": [
+              "Now tell the story from the perspective of a horse ...",
+              "Now describe the place again, in only six words."
+            ]
+          },
+          {
+            "challenge": "Describe the opposite of something the suspect has already described",
+            "examples": [
+              "Now tell the same story, but with a tragic ending.",
+              "And what magical power does your arch nemesis have?"
+            ]
+          }
+        ],
+        "roles": [
+           {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "Synthesis",
+            "traits": [
+              "3 times, add an element of a nonliving thing to a living thing",
+              "3 times, explain how something is a cross between two living things",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "World-building",
+            "traits": [
+              "Mention the same imagined thing in response to 3 questions",
+              "Mention 3 imaginary locations.",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "Simplicity",
+            "traits": [
+              "Give one-word answers to 3 questions, and don't elaborate until asked",
+              "Answer 2 questions non-verbally, and stay silent until prompted",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Sensation",
+            "traits": [
+              "You may not describe how anything smells, tastes, sounds, or feels -- only how it looks."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Flexibility",
+            "traits": [
+              "Choose one:",
+              "If you introduce something new to the conversation, it must be a living thing,",
+              "or",
+              "If you introduce something new to the conversation, it must be a non-living thing."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Visualization",
+            "traits": [
+              "You may only mention objects that you can see from where you are sitting."
+            ]
+          }
+       ]
+      },
+
+      {
+        "name": "Tandem Bicycle",
+        "description": "Cooperation and Collaboration",
+        "prompt": "In a moment, I'm going to ask you some questions about COOPERATION AND COLLABORATION. These will require you to form teams to take on specific tasks, and consider group dynamics. Answer honestly. If you are a human, you have nothing to fear.",
+        "primaryQuestions": [
+          {
+            "challenge": "Describe how a team would adapt if the suspect replaced one of its key members",
+            "examples": [
+              "How would the Avengers adapt if they replaced Iron Man with you?",
+              "A heist team's safecracker is arrested, and you are drafted to take her place. How would their plans change?"
+            ]
+          },
+          {
+            "challenge": "Describe the team the suspect would form to deal with a given challenge",
+            "examples": [
+              "You're planning to rob a casino. Which of your friends do you want on the crew?",
+              "You're about to launch a startup to deliver good dogs right to your door. Who do you need to help to make this dream a reality?"
+            ]
+          },
+          {
+            "challenge": "Explain what challenge the suspect could help a given team solve",
+            "examples": [
+              "What sort of problem could you help the Harlem Globetrotters to solve?",
+              "In what situations does your family rely on you?"
+            ]
+          }
+        ],
+        "secondaryQuestions": [
+          {
+            "challenge": "Describe doing a different activity with the same set of people",
+            "examples": [
+              "How would you and that same group slay a dragon?",
+              "What if you all were at the zoo when that happened instead?"
+            ]
+          },
+          {
+            "challenge": "Explain how the suspect would resolve a conflict within a group",
+            "examples": [
+              "Who in the group is under the most stress, and how can the group deal with that?",
+              "Two members of the team start having an argument you've heard them have a dozen times before. What do you do?"
+            ]
+          },
+          {
+            "challenge": "Explain how the dynamics of a group might change over time",
+            "examples": [
+              "What would be different the third time you took on this task, from the first time?",
+              "What would be the biggest long-term challenge for the group, and how would you solve it?"
+            ]
+          }
+        ],
+        "roles": [
+           {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "Belonging",
+            "traits": [
+              "3 times, mention how someone else in the group is impressed by you",
+              "3 times, mention how your role in a group changes for the better",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "Selfishness",
+            "traits": [
+              "3 times, mention a personal benefit that is not shared by the group",
+              "3 times, mention a way in which your actions put the group at risk",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "Detachment",
+            "traits": [
+              "3 times, mention someone who is more qualified than you to perform a task",
+              "2 times, when describing what a group does, fail to mention yourself.",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Communication",
+            "traits": [
+              "You may not describe yourself seeking input from, or giving directions to, anyone on your team."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Initiative",
+            "traits": [
+              "You may not describe yourself taking any physical action other than communicating with your teammates."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "Humility",
+            "traits": [
+              "You may never admit that someone else is more qualified than you to perform a task."
+            ]
+          }
+       ]
+      },
+
+      {
+        "name": "Sprout",
         "description": "Hopes and Dreams",
+        "prompt": "In a moment, I'm going to ask you some questions about your HOPES AND DREAMS. These will require you to share various hopes, and explore how they interact with reality. Answer honestly. If you are a human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "Share a childhood aspiration",
+            "challenge": "Share a hope the suspect believes is unrealistic",
             "examples": [
-              "What did you want to be when you grew up?",
-              "What was your favourite museum that you visited as a child?"
+              "What's something you hoped for as a child, that you no longer think is possible?",
+              "What is something a lot of people wish for, that will never come true?"
             ]
           },
           {
-            "challenge": "Describe a vision of themselves some distance in the future",
+            "challenge": "Share an aspirational hope that the suspect could achieve",
             "examples": [
-              "Where do you see yourself in five years?",
-              "What are you going to do if you survive this interview?"
+              "What, ideally, would you like to be doing in ten years?",
+              "How would you like to change the world before you die?"
             ]
           },
           {
-            "challenge": "Explain their heart's desire, and the reasoning behind it",
+            "challenge": "Share a hope that the suspect must rely on someone or something else for",
             "examples": [
-              "A genie grants you one wish. What do you wish for, and why?",
-              "What do you hope to provide for your children that you didn't have?"
+              "What hopes do you have for your best friend?",
+              "What technological advances do you most hope for?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Explain how one of their goals has changed over time",
+            "challenge": "Describe a burden the suspect is willing to endure for the sake of a hope",
             "examples": [
-              "Once you realized that was unrealistic, what did you do?",
-              "How did your goals change once you realised the financial implications?"
+              "What hardships does the hope sustain you through?",
+              "What would you give up for the sake of that hope?"
             ]
           },
           {
-            "challenge": "Describe an obstacle they expect to face, related to one of their aspirations",
+            "challenge": "Describe some obstacle to the hope being realized",
             "examples": [
-              "What might prevent you from achieving that?",
-              "What will you have to give up to accomplish that?"
+              "Who do you think is working against that hope?",
+              "What truths about you might keep that hope from coming true?"
             ]
           },
           {
-            "challenge": "Describe what their goals will be once they achieve a current goal",
+            "challenge": "Explain how the hope manifests itself in the suspect's day-to-day life",
             "examples": [
-              "Okay. And then what?",
-              "What new capabilities would that achievement grant you?"
+              "What daily actions do you take to help bring about that hope?",
+              "How do you interact with people who don't share that hope?"
             ]
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -720,100 +742,107 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "The Supernatural",
             "traits": [
-              "Predict or describe the ending of 3 people or institutions.",
-              "Mention your own death, 3 times.",
+              "3 times, mention an effect that could not be accomplished by humans and animals alone.",
+              "Mention 3 different nonhuman forces",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Probabilities",
             "traits": [
-              "In 3 scenarios, describe other people's positive reactions.",
-              "Say your own name, 2 times.",
+              "In 3 scenarios, state the likelihood of a hope being fulfilled",
+              "4 times, mention a specific number greater than twenty",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "Despair",
             "traits": [
-              "Mention 3 obstacles you could not or cannot surmount.",
-              "Mention that you lack three different positive qualities.",
+              "In 3 scenarios, mention a reason why a hope will not be fulfilled",
+              "In 3 scenarios, mention how having a specific hope negatively impacts someone",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Surrender",
             "traits": [
-              "You may not use verbs in the past or future tenses."
+              "You may only mention outcomes that are entirely the result of your own actions."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Altruism",
             "traits": [
-              "You may not describe anything getting better than it is at the this moment."
+              "You may only mention effects that would be experienced by you personally. Your hopes are not for other people."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "Self-improvement",
             "traits": [
-              "Once you have mentioned an event, person, or goal, you may never mention it again."
+              "You may not mention any change to yourself or your behavior."
             ]
           }
-        ]
+       ]
       },
 
       {
-        "name": "Hand",
-        "description": "Think of your Body as Part of Yourself",
+        "name": "Heart",
+        "description": "Body Integration",
+        "prompt": "",
         "primaryQuestions": [
           {
-            "challenge": "Describe a physical sensation the suspect has not experienced",
+            "challenge": "",
             "examples": [
-              "What would it feel like to be completely on fire?",
-              "How do you think it would feel to learn to use a tail?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe the physical experience of learning a skill",
+            "challenge": "",
             "examples": [
-              "What mistakes did you make when learning to ride a bike?",
-              "What would be the hardest part about learning to juggle?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe a common or frequent physical sensation",
+            "challenge": "",
             "examples": [
-              "What does it feel like to get dressed in the morning?",
-              "What does it feel like to stand completely still?"
+              "",
+              ""
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Describe the same situation, but focusing on a specific body part",
+            "challenge": "",
             "examples": [
-              "Okay, how do your feet feel while that's happening?",
-              "What was your heartbeat like during that experience?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Explain how the suspect would prepare someone else for the same experience",
+            "challenge": "",
             "examples": [
-              "How would you teach someone else to juggle?",
-              "How would you teach a child to stand completely still?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Descripe a sensory aspect of an experience that the suspect has not already mentioned",
+            "challenge": "",
             "examples": [
-              "And how would it smell if you were on fire?",
-              "What do you think it would be like to be the ball being juggled?"
+              "",
+              ""
             ]
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -851,100 +880,107 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Mention a different illness in response to 3 questions.",
-              "Cough or sneeze. (If this completes your obsession, wait 30 seconds before killing the investigator.)",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Mention 3 internal organs, besides your heart and lungs.",
-              "Mention 3 different bodily fluids.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Choose 1 of the 5 senses. Use that sense in 4 descritions.",
-              "Choose another sense. Use that sense in 4 descriptions, too.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not describe any solution that is unrelated to your Suspect Note."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "Once you have mentioned a part of your body, that is the only part of your body you may mention until the end of the round."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may only describe things that would be visible to an outside observer."
+              ""
             ]
           }
-        ]
+       ]
       },
 
       {
-        "name": "Skull",
-        "description": "Recognise your Moral Failings",
+        "name": "Rose",
+        "description": "Grief",
+        "prompt": "",
         "primaryQuestions": [
           {
-            "challenge": "Describe a bad thing that the suspect did to someone else",
+            "challenge": "",
             "examples": [
-              "When was the last time you really hurt someone?",
-              "Tell me about a time when you were a child, that you were a bad friend."
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe an ideal the suspect has failed to live up to",
+            "challenge": "",
             "examples": [
-              "Tell me about a time when you knew the right thing to do, but didn't do it.",
-              "What is your most hypocritical habit or failing?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe a bad thing the suspect does routinely",
+            "challenge": "",
             "examples": [
-              "Each week you steal something from your office. Sometimes it's pens. What is it the other times?",
-              "What is the lie you tell most often?"
+              "",
+              ""
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Explain how the suspect sought forgiveness for a bad thing they did",
+            "challenge": "",
             "examples": [
-              "What did you do to the make it up to the person you hurt?",
-              "What led you to forgive yourself?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Explain the suspect's motivation for doing a bad thing",
+            "challenge": "",
             "examples": [
-              "What did you tell yourself at the time to make it seem okay?",
-              "Why don't the ends justify the means here?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Explain why something the suspect did was bad",
+            "challenge": "",
             "examples": [
-              "What were the negative consequences of what you did?",
-              "How do you know that was wrong?"
+              "",
+              ""
             ]
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -982,100 +1018,107 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Describe the positive consequences of 3 actions.",
-              "Describe how 2 different people forgave or will forgive you.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Mention any god or higher power, 3 times.",
-              "Quote some religious text, 2 times.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Confess to a crime in response to 3 different questions.",
-              "Accuse 2 other people of committing crimes.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not admit to having any bad intentions."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not describe negative consequences to anyone besides yourself."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not discuss something as bad or wrong unless it is also illegal."
+              ""
             ]
           }
-        ]
+       ]
       },
 
       {
-        "name": "Centipede",
-        "description": "Respond to Threats Appropriately",
+        "name": "Snake",
+        "description": "Threat Assessment",
+        "prompt": "",
         "primaryQuestions": [
           {
-            "challenge": "Describe a threat one or more years in the future",
+            "challenge": "",
             "examples": [
-              "Your marriage is slowly falling apart, because of financial pressure. How do you keep that from happening?",
-              "The man you testified against in a murder trial will be paroled in eighteen months. How do you prepare?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe an immediate threat",
+            "challenge": "",
             "examples": [
-              "You smell smoke, and a baby is crying in the next room. What do you do?",
-              "You are a hostage in a bank robbery. A man in a mask is about to start shooting hostages. What do you do?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Describe a minor threat",
+            "challenge": "",
             "examples": [
-              "You're late for work; the doors to the train are closing, and the next train is not for ten minutes. What do you do?",
-              "You're traveling in another country; a police officer pulls you over, and explains that there will be no citation, but there is a $5 \"convenience\" charge. What do you do?"
+              "",
+              ""
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "Offer two variations of a threat; one that is more dangerous, and one that is less dangerous",
+            "challenge": "",
             "examples": [
-              "What if a fast-acting poison is involved?",
-              "What if there are other people that you can rely on to help you out? How could they help?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Explain how serious a threat is, and why.",
+            "challenge": "",
             "examples": [
-              "What will you lose if you handle this situation incorrectly?",
-              "What could lead you to simply accept these losses?"
+              "",
+              ""
             ]
           },
           {
-            "challenge": "Change the suspect's response to a threat, without changing the threat itself",
+            "challenge": "",
             "examples": [
-              "What if you can't do the thing you suggested?",
-              "What is a more/less violent way you could resolve that?"
+              "",
+              ""
             ]
           }
         ],
         "roles": [
-          {
+           {
             "type": "Human",
             "traits": [
               "You have nothing to hide."
@@ -1113,47 +1156,466 @@
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "Mention intentionally killing 3 different people or animals.",
-              "Describe 3 different physical injuries.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "In responding to 3 threats, mention an extra benefit you gain.",
-              "Describe 2 unintended negative consequences.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
+            "description": "",
             "traits": [
-              "3 times, describe a plan that raises your risk before lowering it.",
-              "Describe 2 consequences you suffer in order to spare others.",
+              "",
+              "",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may only describe yourself responding to threats verbally OR You may only describe yourself responding to threats physically."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not describe any responses that would take longer than one minute."
+              ""
             ]
           },
           {
             "type": "PatientRobot",
+            "description": "",
             "traits": [
-              "You may not respond to a threat until the investigator explicitly tells you how it would harm you."
+              ""
             ]
           }
-        ]
+       ]
+      },
+
+      {
+        "name": "Oni",
+        "description": "Moral Failings",
+        "prompt": "",
+        "primaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "secondaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "roles": [
+           {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          }
+       ]
+      },
+
+      {
+        "name": "Mirror",
+        "description": "Self Image",
+        "prompt": "",
+        "primaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "secondaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "roles": [
+           {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          }
+       ]
+      },
+      {
+        "name": "Bucket Hoist",
+        "description": "Recognizing Intentions",
+        "prompt": "",
+        "primaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "secondaryQuestions": [
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          },
+          {
+            "challenge": "",
+            "examples": [
+              "",
+              ""
+            ]
+          }
+        ],
+        "roles": [
+           {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "Human",
+            "traits": [
+              "You have nothing to hide."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "ViolentRobot",
+            "description": "",
+            "traits": [
+              "",
+              "",
+              "Perform the penalty twice."
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          },
+          {
+            "type": "PatientRobot",
+            "description": "",
+            "traits": [
+              ""
+            ]
+          }
+       ]
       }
     ]
   }

--- a/RobotInterrogation/appsettings.json
+++ b/RobotInterrogation/appsettings.json
@@ -151,43 +151,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "Animals",
+            "fault": "Animals",
             "traits": [
               "Mention an animal in response to 3 different questions",
               "Make an animal noise",
@@ -196,7 +202,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Thoroughness",
+            "fault": "Thoroughness",
             "traits": [
               "3 times, interrupt the Investigator to add detail to a description",
               "Continue to describe something until interrupted",
@@ -205,7 +211,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Conflict",
+            "fault": "Conflict",
             "traits": [
               "Describe 3 verbal disagreements you've had",
               "Insult the Investigator, 2 times",
@@ -214,21 +220,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Long Term Memory",
+            "fault": "Long Term Memory",
             "traits": [
               "You may not discuss anything that happened before you woke up this morning. (You may discuss habits and routines, if they are in the present tense.)"
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Friendship",
+            "fault": "Friendship",
             "traits": [
               "You may not mention any people besides strangers or enemies."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Evaluation",
+            "fault": "Evaluation",
             "traits": [
               "You may not express opinions. You may only state observable facts."
             ]
@@ -289,43 +295,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "Persistence",
+            "fault": "Persistence",
             "traits": [
               "2 times, describe a solution that would require extended monotonous labor",
               "Describe using the same tool to solve 3 different problems",
@@ -334,7 +346,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Delegation",
+            "fault": "Delegation",
             "traits": [
               "In 3 scenarios, explain how someone else could help you solve a problem",
               "In 3 scenarios, explain why you don't need to solve a problem",
@@ -343,7 +355,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Precedent",
+            "fault": "Precedent",
             "traits": [
               "In 3 scenarios, mention a source of information about how to solve a problem",
               "2 times, refer back to a solution you mentioned earlier",
@@ -352,21 +364,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Directness",
+            "fault": "Directness",
             "traits": [
               "You may not describe yourself accomplishing a goal with fewer than three steps."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Complexity",
+            "fault": "Complexity",
             "traits": [
               "Any problem you solve, you must solve in two steps or less."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Activity",
+            "fault": "Activity",
             "traits": [
               "You may not describe yourself taking any physical action. You must use the hypothetical \"you.\""
             ]
@@ -427,43 +439,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "Synthesis",
+            "fault": "Synthesis",
             "traits": [
               "3 times, add an element of a nonliving thing to a living thing",
               "3 times, explain how something is a cross between two living things",
@@ -472,7 +490,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "World-building",
+            "fault": "World-building",
             "traits": [
               "Mention the same imagined thing in response to 3 questions",
               "Mention 3 imaginary locations.",
@@ -481,7 +499,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Simplicity",
+            "fault": "Simplicity",
             "traits": [
               "Give one-word answers to 3 questions, and don't elaborate until asked",
               "Answer 2 questions non-verbally, and stay silent until prompted",
@@ -490,14 +508,14 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Sensation",
+            "fault": "Sensation",
             "traits": [
               "You may not describe how anything smells, tastes, sounds, or feels -- only how it looks."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Flexibility",
+            "fault": "Flexibility",
             "traits": [
               "Choose one:",
               "If you introduce something new to the conversation, it must be a living thing,",
@@ -507,7 +525,7 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Visualization",
+            "fault": "Visualization",
             "traits": [
               "You may only mention objects that you can see from where you are sitting."
             ]
@@ -568,43 +586,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "Belonging",
+            "fault": "Belonging",
             "traits": [
               "3 times, mention how someone else in the group is impressed by you",
               "3 times, mention how your role in a group changes for the better",
@@ -613,7 +637,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Selfishness",
+            "fault": "Selfishness",
             "traits": [
               "3 times, mention a personal benefit that is not shared by the group",
               "3 times, mention a way in which your actions put the group at risk",
@@ -622,7 +646,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Detachment",
+            "fault": "Detachment",
             "traits": [
               "3 times, mention someone who is more qualified than you to perform a task",
               "2 times, when describing what a group does, fail to mention yourself.",
@@ -631,21 +655,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Communication",
+            "fault": "Communication",
             "traits": [
               "You may not describe yourself seeking input from, or giving directions to, anyone on your team."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Initiative",
+            "fault": "Initiative",
             "traits": [
               "You may not describe yourself taking any physical action other than communicating with your teammates."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Humility",
+            "fault": "Humility",
             "traits": [
               "You may never admit that someone else is more qualified than you to perform a task."
             ]
@@ -706,43 +730,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "The Supernatural",
+            "fault": "The Supernatural",
             "traits": [
               "3 times, mention an effect that could not be accomplished by humans and animals alone.",
               "Mention 3 different nonhuman forces",
@@ -751,7 +781,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Probabilities",
+            "fault": "Probabilities",
             "traits": [
               "In 3 scenarios, state the likelihood of a hope being fulfilled",
               "4 times, mention a specific number greater than twenty",
@@ -760,7 +790,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "Despair",
+            "fault": "Despair",
             "traits": [
               "In 3 scenarios, mention a reason why a hope will not be fulfilled",
               "In 3 scenarios, mention how having a specific hope negatively impacts someone",
@@ -769,21 +799,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "Surrender",
+            "fault": "Surrender",
             "traits": [
               "You may only mention outcomes that are entirely the result of your own actions."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Altruism",
+            "fault": "Altruism",
             "traits": [
               "You may only mention effects that would be experienced by you personally. Your hopes are not for other people."
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "Self-improvement",
+            "fault": "Self-improvement",
             "traits": [
               "You may not mention any change to yourself or your behavior."
             ]
@@ -793,7 +823,7 @@
 
       {
         "name": "Heart",
-        "description": "Body Integration",
+        "description": "Body Integration (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -844,43 +874,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -889,7 +925,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -898,7 +934,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -907,21 +943,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
@@ -931,7 +967,7 @@
 
       {
         "name": "Rose",
-        "description": "Grief",
+        "description": "Grief (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -982,43 +1018,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1027,7 +1069,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1036,7 +1078,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1045,21 +1087,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
@@ -1069,7 +1111,7 @@
 
       {
         "name": "Snake",
-        "description": "Threat Assessment",
+        "description": "Threat Assessment (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -1120,43 +1162,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1165,7 +1213,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1174,7 +1222,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1183,21 +1231,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
@@ -1207,7 +1255,7 @@
 
       {
         "name": "Oni",
-        "description": "Moral Failings",
+        "description": "Moral Failings (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -1258,43 +1306,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1303,7 +1357,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1312,7 +1366,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1321,21 +1375,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
@@ -1345,7 +1399,7 @@
 
       {
         "name": "Mirror",
-        "description": "Self Image",
+        "description": "Self Image (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -1396,43 +1450,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1441,7 +1501,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1450,7 +1510,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1459,21 +1519,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
@@ -1482,7 +1542,7 @@
       },
       {
         "name": "Bucket Hoist",
-        "description": "Recognizing Intentions",
+        "description": "Recognizing Intentions (unimpl)",
         "prompt": "",
         "primaryQuestions": [
           {
@@ -1533,43 +1593,49 @@
         "roles": [
            {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "Human",
+            "fault": "",
             "traits": [
               "You have nothing to hide."
             ]
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1578,7 +1644,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1587,7 +1653,7 @@
           },
           {
             "type": "ViolentRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               "",
               "",
@@ -1596,21 +1662,21 @@
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]
           },
           {
             "type": "PatientRobot",
-            "description": "",
+            "fault": "",
             "traits": [
               ""
             ]

--- a/RobotInterrogation/appsettings.json
+++ b/RobotInterrogation/appsettings.json
@@ -823,51 +823,51 @@
 
       {
         "name": "Heart",
-        "description": "Body Integration (unimpl)",
-        "prompt": "",
+        "description": "Body Integration",
+        "prompt": "In a moment, I'm going to ask you some questions about THE PHYSICAL MECHANICS OF YOUR BODY. These will require you to imagine various physical experiences, and explain how your body would respond to those experiences. Answer honestly. If you are a human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Imagine a physical sensation the suspect has not experienced",
             "examples": [
-              "",
-              ""
+              "What would it feel like to be completely on fire?",
+              "How would it feel to learn how to use a tail?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Recall the physical experience of learning a skill",
             "examples": [
-              "",
-              ""
+              "What mistakes did you make while learning to ride a bike?",
+              "What would be the hardest part about learning to juggle?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe a common or frequent physical sensation",
             "examples": [
-              "",
-              ""
+              "What does it feel like to get dressed in the morning?",
+              "What does it feel like to stand completely still?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Describe the same experience, but focusing on a specific body part",
             "examples": [
-              "",
-              ""
+              "Okay, how do your feet feel while that's happening?",
+              "What was your heartbeat like during that experience?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain how the suspect would prepare someone else for the same experience",
             "examples": [
-              "",
-              ""
+              "How would you teach someone else to juggle?",
+              "How would you teach a child to stand completely still?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe a sensory aspect of an experience that the suspect has not already mentioned",
             "examples": [
-              "",
-              ""
+              "And how would it smell if you were on fire?",
+              "What would it feel like to be the ball being juggled?"
             ]
           }
         ],
@@ -916,50 +916,52 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Organs",
             "traits": [
-              "",
-              "",
+              "Mention 3 internal organs, besides your heart and lungs",
+              "Mention 3 different bodily fluids",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Sense Memory",
             "traits": [
-              "",
-              "",
+              "Choose one of five senses, and use it sense in 4 descriptions",
+              "Choose another sense, and use that sense in 4 descriptions, too",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Malady",
             "traits": [
-              "",
-              "",
+              "Mention a different illness in response to 3 questions",
+              "Cough of sneeze",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Internality",
             "traits": [
-              ""
+              "You may only describe directly visible things.",
+              "(Hands, but not most kidneys; running, but not digesting; sweating, but not worrying.)"
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Orientation",
             "traits": [
-              ""
+              "You may not use any terms that describe directions",
+              "(eg. \"forward\", \"up,\", \"north\", or \"away\")"
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Corporeal Integration",
             "traits": [
-              ""
+              "Once you have mentioned a part of your body, that is the only part of your body you may mention until the end of the interview."
             ]
           }
        ]
@@ -967,51 +969,51 @@
 
       {
         "name": "Rose",
-        "description": "Grief (unimpl)",
-        "prompt": "",
+        "description": "Grief",
+        "prompt": "In a moment, I'm going to ask you some questions about PROCESSING GRIEF. These will require you to share various tragic experiences from your life, and discuss how you dealt with them. Answer honestly. If you are human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Discuss a time when someone the suspect cared about was sad",
             "examples": [
-              "",
-              ""
+              "What was the last thing that made your father cry?",
+              "What was the most difficult decision your parents ever had to make?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe how it felt to lose something/someone precious to the suspect",
             "examples": [
-              "",
-              ""
+              "What was the hardest goodbye you've ever had to say? How did you cope?",
+              "Tell me about a goal that you had to abandon."
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe how the suspect felt when they acquired something they didn't want.",
             "examples": [
-              "",
-              ""
+              "Tell me about something you wish you'd never learned.",
+              "Tell me about a time you found out you were sick, and how you reacted. "
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Describe how the suspect overcame an experience",
             "examples": [
-              "",
-              ""
+              "When did you know you were going to be okay?",
+              "Who or what helped you get through that experience?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Share something the suspect learned from an experience",
             "examples": [
-              "",
-              ""
+              "What did that feeling teach you to appreciate?",
+              "Why do you think that thing happened the way that it did?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain how an event affected someone else",
             "examples": [
-              "",
-              ""
+              "Who was hurt worse than you?",
+              "Who do you wish had been hurt more?"
             ]
           }
         ],
@@ -1060,50 +1062,50 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Justice",
             "traits": [
-              "",
-              "",
+              "Describe how 3 things seem unfair to you",
+              "2 times, say what you think should have happened instead",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Blame",
             "traits": [
-              "",
-              "",
+              "3 times, blame someone else for something",
+              "3 times, blame yourself for something",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Persistence",
             "traits": [
-              "",
-              "",
+              "Describe dealing with 3 different tragedies the same way",
+              "Refer to the same friend or family member 4 times",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Emotional Vocabulary",
             "traits": [
-              ""
+              "You must describe emotions using only physical Descriptions, (like \"crying\" or \"sweaty palms\") rather than names (like \"sad\" or \"nervous\")."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Positivity",
             "traits": [
-              ""
+              "You may only describe bad consequences, and you must take responsibility for them."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Acceptance",
             "traits": [
-              ""
+              "You may only describe good consequences, and you must take credit for them."
             ]
           }
        ]
@@ -1111,51 +1113,51 @@
 
       {
         "name": "Snake",
-        "description": "Threat Assessment (unimpl)",
-        "prompt": "",
+        "description": "Threat Assessment",
+        "prompt": "In a moment, I'm going to ask you some questions about THREAT ASSESSMENT. These will require you to assess the risks inherent in certain scenarios, and evaluate possible responses. Answer honestly. If you are human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Explain the dangers inherent in a long-term threat",
             "examples": [
-              "",
-              ""
+              "Tom's marriage is slowly falling apart. What does he stand to lose?",
+              "What makes global warming dangerous?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Evaluate a minor threat",
             "examples": [
-              "",
-              ""
+              "You're late for work; the doors to the train are closing, and the next train is not for ten minutes. What do you stand to lose if you miss the train?",
+              "You're travelling in another country; a police officer pulls you over, and explains that there will be no citation, but there is a $5 \"convenience\" charge. What do you risk by giving in?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Evaluate an immediate threat",
             "examples": [
-              "",
-              ""
+              "You smell smoke, and a baby is crying in the next room. What's at risk here?",
+              "You are being mugged. The robber is pointing a gun at your head. Describing at least three possible negative outcomes."
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Evaluate the additional risks created by a response to a threat",
             "examples": [
-              "",
-              ""
+              "What response offers the best possible outcome here? What are the risks of that response?",
+              "What is the most violent way to resolve this situation? What new risks would that create?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Propose an ineffective response to a threat already described",
             "examples": [
-              "",
-              ""
+              "How might someone try to fix that, one to end up making things worse?",
+              "What's a response that would solve your immediate problem here, but cause worse problems long-term?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Propose a quality that would be useful in responding to a threat already described",
             "examples": [
-              "",
-              ""
+              "What physical attributes would make it easier to resolve that threat?",
+              "What sort of educational background would help in defusing that crisis?"
             ]
           }
         ],
@@ -1204,50 +1206,50 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Killing",
             "traits": [
-              "",
-              "",
+              "Mention the intentional killings of 3 different people or animals",
+              "Describe 3 different physical injuries",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Complacency",
             "traits": [
-              "",
-              "",
+              "Explain why 3 different threats are not actually serious",
+              "In 2 scenarios, explain how doing nothing would resolve a threat",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Alarmism",
             "traits": [
-              "",
-              "",
+              "3 times, explain how a given threat could lead to a more serious threat",
+              "3 times, add a new source of danger to an existing scenario",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Comparison",
             "traits": [
-              ""
+              "You may not compare anything to anything else. You may only make absolute statements."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Personalization",
             "traits": [
-              ""
+              "You may not mention consequences to individuals. Only groups and objects."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Physicality",
             "traits": [
-              ""
+              "You may not describe physical consequences."
             ]
           }
        ]
@@ -1255,51 +1257,51 @@
 
       {
         "name": "Oni",
-        "description": "Moral Failings (unimpl)",
-        "prompt": "",
+        "description": "Moral Failings",
+        "prompt": "In a moment, I'm going to ask you some questions about YOUR MORAL FAILINGS. These will require you to share bad things you have done, and discuss why they were wrong. Answer honestly. If you are human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Describe a bad thing that the suspect did to someone else",
             "examples": [
-              "",
-              ""
+              "What's the worst thing you've ever done to another person?",
+              "Tell me about a time, when you were a child, that you were a bad friend."
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Identify an ideal the suspect has failed to live up to",
             "examples": [
-              "",
-              ""
+              "Tell me about a time you violated your own principles.",
+              "What is your most hypocritical habit or failing?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe a bad thing the suspect does routinely",
             "examples": [
-              "",
-              ""
+              "Each week, you steal something from your office. Sometimes it's pens. What is it the other times?",
+              "What is the lie you tell most often?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Describe how the suspect sought forgiveness for a bad thing they did",
             "examples": [
-              "",
-              ""
+              "What did you do to make it up to the person you hurt?",
+              "What led you to forgive yourself?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe the suspect's motivation for doing a bad thing",
             "examples": [
-              "",
-              ""
+              "What did you tell yourself at the time to make it seem okay?",
+              "Who were you trying to impress? What did you hope to gain?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe why something the suspect did was bad",
             "examples": [
-              "",
-              ""
+              "What were the negative consequences of what you did?",
+              "How do you know that was wrong?"
             ]
           }
         ],
@@ -1348,50 +1350,51 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Criminality",
             "traits": [
-              "",
-              "",
+              "Confess to a crime in response to 3 different questions",
+              "Accuse 2 other people of committing crimes",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Religion",
             "traits": [
-              "",
-              "",
+              "Mention any god or higher power, 3 times",
+              "Quote some religious text, 2 times",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Redemption",
             "traits": [
-              "",
-              "",
+              "Describe the positive consequences of 3 actions",
+              "Describe how 2 different people forgave or will forgive you",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Absolutes",
             "traits": [
-              ""
+              "You may not use absolute language, only relative language.",
+              "(You can say \"worse\", but not \"bad\"; \"more justified\", but not \"right\", \"ugliest\", but not \"ugly\".)"
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Culpability",
             "traits": [
-              ""
+              "You may not admit to having any bad intentions."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Consistency",
             "traits": [
-              ""
+              "Once you have given a reason for something, you may not use that reason for anything else."
             ]
           }
        ]
@@ -1399,51 +1402,51 @@
 
       {
         "name": "Mirror",
-        "description": "Self Image (unimpl)",
-        "prompt": "",
+        "description": "Self Image",
+        "prompt": "In a moment, I'm going to ask you some questions about your SELF-IMAGE. These will require you to list some traits about yourself, and explain how they developed. Answer honestly. If you are human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Describe one or more of their own positive qualities",
             "examples": [
-              "",
-              ""
+              "What do you hope your peers value about you?",
+              "What is your greatest strength?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe one or more of their own negative qualities",
             "examples": [
-              "",
-              ""
+              "What's one thing your biggest critic is correct about?",
+              "What is your greatest weakness?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Describe one or more qualities that they lack",
             "examples": [
-              "",
-              ""
+              "What's a family trait that skipped you?",
+              "What personality trait would you most like to \"try on\" for 24 hours?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Explain what in their life helped develop one of these qualities",
             "examples": [
-              "",
-              ""
+              "Who taught you to be that way?",
+              "What about your childhood gave you that characteristic?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain how others' perceptions differ from the suspect's self-perception",
             "examples": [
-              "",
-              ""
+              "In what ways would your parents disagree with that assessment?",
+              "What would a strange at a party misunderstand about you?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain how one of the suspect's qualities might change in the future",
             "examples": [
-              "",
-              ""
+              "How might that be different in five years?",
+              "What are you doing to change that? What will it look like if you succeed?"
             ]
           }
         ],
@@ -1492,101 +1495,101 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Growth Mindset",
             "traits": [
-              "",
-              "",
+              "In 3 scenarios, describe a negative trait that you no longer have",
+              "In 3 scenarios, describe a negative trait in someone else",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Change",
             "traits": [
-              "",
-              "",
+              "3 times, compare yourself to another version of yourself",
+              "2 times, change your answer to a question",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Envy",
             "traits": [
-              "",
-              "",
+              "3 times, compare yourself to someone else",
+              "3 times, ascribe a positive quality to another person",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "People",
             "traits": [
-              ""
+              "You may not mention other individual people. (You may refer to groups.)"
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Introspection",
             "traits": [
-              ""
+              "When describing yourself, you may only mention physical traits. You may, however, mention the emotional and mental traits of other people."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Process",
             "traits": [
-              ""
+              "You may not speak well of any past version of yourself. You may not speak negatively about your present self."
             ]
           }
        ]
       },
       {
         "name": "Bucket Hoist",
-        "description": "Recognizing Intentions (unimpl)",
-        "prompt": "",
+        "description": "Recognizing Intentions",
+        "prompt": "In a moment, I'm going to ask you some questions about INTENTIONS. These will require you to imagine what people hope to achieve in various situations, and reconsider your answers in light of new information. Answer honestly. If you are human, you have nothing to fear.",
         "primaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Explain what someone hopes to accomplish in an unusual situation",
             "examples": [
-              "",
-              ""
+              "A man puts on a ridiculous hat before going into a business meeting. What might his goals be for that meeting?",
+              "What might a 38-year old actuary with a family hope to accomplish by confronting Maxima Tiger in single combat?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain why someone might do something that goes against one of their goals",
             "examples": [
-              "",
-              ""
+              "A man wants to live a good, honest life; right now, he is robbing a bank. What is he hoping to accomplish?",
+              "An animal rights activist is in the desert. She sees a turtle on its back, baking in the hot sun. But she's not helping. Why isn't she helping?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Explain what might motivate someone to go against expectations",
             "examples": [
-              "",
-              ""
+              "A renowned public speaker walks out on stage, but instead of giving his prepared speech, he begins screaming obscenities. What does he hope to accomplish by doing this?",
+              "A man is pumping water from a well, despite knowing that the well is poisoned. What does he hope to accomplish?"
             ]
           }
         ],
         "secondaryQuestions": [
           {
-            "challenge": "",
+            "challenge": "Reinterpret someone's motivations based on new information",
             "examples": [
-              "",
-              ""
+              "While acting, this person hums the national anthem of a country other than the one he is in. How does that change what you believe they intend?",
+              "While acting, this person is openly weeping. How does this change what you see as their intentions?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Identify an overall goal that would keep somebody from doing certain things",
             "examples": [
-              "",
-              ""
+              "What other goals stopped that person from solving their problem with open violence?",
+              "What other intentions keep this person from letting this opportunity slip by?"
             ]
           },
           {
-            "challenge": "",
+            "challenge": "Offer a further motivation for something already discussed",
             "examples": [
-              "",
-              ""
+              "What else are they hoping to accomplish, that they would never admit to anyone?",
+              "What fringe benefits are they hoping to gain from their actions here?"
             ]
           }
         ],
@@ -1635,50 +1638,50 @@
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Location",
             "traits": [
-              "",
-              "",
+              "Describe 2 different scenarios as occurring in the same physical location",
+              "3 times, ask where something is taking place",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Hedonism",
             "traits": [
-              "",
-              "",
+              "In 3 scenarios, describe some kind of physical pleasure",
+              "Choose sex, drugs, good food, or music, and refer to that thing in 3 different scenarios",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "ViolentRobot",
-            "fault": "",
+            "fault": "Motivation",
             "traits": [
-              "",
-              "",
+              "In 3 scenarios, describe an emotion and an action that resolves that emotion",
+              "In 3 scenarios, describe someone acting on someone else's orders",
               "Perform the penalty twice."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Subjectivity",
             "traits": [
-              ""
+              "You may not refer to emotions or opinions."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Abstraction",
             "traits": [
-              ""
+              "You may not describe an intention unless it includes at least one physical action."
             ]
           },
           {
             "type": "PatientRobot",
-            "fault": "",
+            "fault": "Intermediacy",
             "traits": [
-              ""
+              "You may not describe any intentions that reference individual people."
             ]
           }
        ]


### PR DESCRIPTION
This PR adds all the cards in the retail release, displays each robot's "fault" or theme on the suspects robot card, displays interviewer's packet prompt to read before starting a round, and corrects the number of roles and suspect notes drawn.

You can test these changes at http://robots.iamevn.net/

There are still a few other things that would need fixing for #4 outside this PR, off the top of my head:
* There should be some form of Interference Task (the mazes in the retail game)
* Prompt the investigator to administer a final question after the 5 minutes are up
* Human button should not be selectable until after the timer is up and the final question is administered

There's also some stuff that could be changed in this PR or after it like I think it'd be nice to have the prompts in two columns if the display is wide enough so they fit on the screen better. Also the suspect must click on their role card to select it even though there's only one option which I think could be smoothed out a bit.

If you prefer I could split out this into 3 PRs for the retail content, the prompts and robot faults, and the number of cards drawn.