### PR TITLE
Wording of spectator inducer prompt is now dynamic

### DIFF
--- a/RobotInterrogation/ClientApp/src/components/Interview.tsx
+++ b/RobotInterrogation/ClientApp/src/components/Interview.tsx
@@ -130,6 +130,7 @@ export const Interview: React.FunctionComponent<RouteComponentProps<{ id: string
                         position={state.position}
                         packet={state.packet}
                         role={state.role!}
+                        shown={false}
                         connections={state.patternConnections}
                         content={state.patternContent}
                         solution={state.patternSolution}
@@ -164,6 +165,7 @@ export const Interview: React.FunctionComponent<RouteComponentProps<{ id: string
                         position={state.position}
                         packet={state.packet}
                         role={state.role!}
+                        shown={true}
                         connections={state.patternConnections}
                         content={state.patternContent}
                         solution={state.patternSolution}

--- a/RobotInterrogation/ClientApp/src/components/interviewParts/SpectatorInducerDisplay.tsx
+++ b/RobotInterrogation/ClientApp/src/components/interviewParts/SpectatorInducerDisplay.tsx
@@ -14,20 +14,22 @@ interface IProps {
     position: InterviewPosition;
     packet: string;
     role: ISuspectRole;
+    shown: boolean;
     connections?: Direction[][];
     content?: string[][];
     solution?: string[];
 }
 
 export const SpectatorInducerDisplay: React.FunctionComponent<IProps> = props => {
-
+    const correctTense = props.shown ? 'has been' : 'is about to be';
+        
     return (
         <Page>
             <PositionHeader position={props.position} />
 
             <PacketDisplay packet={props.packet} />
 
-            <Typography>The <Help entry="inducer">inducer</Help> has been administered. Suspect's <Help entry="roles">role</Help>:</Typography>
+            <Typography>The <Help entry="inducer">inducer</Help> {correctTense} administered.<br/>Suspect's <Help entry="roles">role</Help>:</Typography>
             <SuspectRole role={props.role} />
 
             {props.solution ? <InterferenceSolution solution={props.solution} /> : undefined}


### PR DESCRIPTION
SpectatorInducerDisplay says that the inducer has been adminstered before it is actually administered.

(It also shows it once it has been administered.)

This component is shown in both the `InducerPrompt` and `ShowingInducer` statuses.

There's no real need to hide any information prior to showing the inducer, this is really just down to the wording.